### PR TITLE
fix(ui): adjust carousel button positioning for improved responsiveness

### DIFF
--- a/clipchronicle-landing/components/ui/carousel.tsx
+++ b/clipchronicle-landing/components/ui/carousel.tsx
@@ -185,8 +185,8 @@ function CarouselPrevious({
       className={cn(
         "absolute size-8 rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+          ? "top-1/2 left-2 -translate-y-1/2 sm:-left-12"
+          : "top-2 left-1/2 -translate-x-1/2 rotate-90 sm:-top-12",
         className,
       )}
       disabled={!canScrollPrev}
@@ -215,8 +215,8 @@ function CarouselNext({
       className={cn(
         "absolute size-8 rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+          ? "top-1/2 right-2 -translate-y-1/2 sm:-right-12"
+          : "bottom-2 left-1/2 -translate-x-1/2 rotate-90 sm:-bottom-12",
         className,
       )}
       disabled={!canScrollNext}

--- a/clipchronicle-landing/components/ui/carousel.tsx
+++ b/clipchronicle-landing/components/ui/carousel.tsx
@@ -118,7 +118,7 @@ function Carousel({
     >
       <div
         onKeyDownCapture={handleKeyDown}
-        className={cn("relative", className)}
+        className={cn("relative w-full", className)}
         role="region"
         aria-roledescription="carousel"
         data-slot="carousel"
@@ -136,7 +136,7 @@ function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       ref={carouselRef}
-      className="overflow-hidden px-3 sm:px-4 md:px-6 py-6"
+      className="w-full overflow-hidden px-3 sm:px-4 md:px-6 py-6"
       data-slot="carousel-content"
     >
       <div
@@ -183,10 +183,10 @@ function CarouselPrevious({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
+        "absolute size-8 rounded-full cursor-pointer",
         orientation === "horizontal"
-          ? "top-1/2 left-2 -translate-y-1/2 sm:-left-12"
-          : "top-2 left-1/2 -translate-x-1/2 rotate-90 sm:-top-12",
+          ? "top-1/2 left-2 -translate-y-1/2"
+          : "top-2 left-1/2 -translate-x-1/2 rotate-90",
         className,
       )}
       disabled={!canScrollPrev}
@@ -213,10 +213,10 @@ function CarouselNext({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
+        "absolute size-8 rounded-full cursor-pointer",
         orientation === "horizontal"
-          ? "top-1/2 right-2 -translate-y-1/2 sm:-right-12"
-          : "bottom-2 left-1/2 -translate-x-1/2 rotate-90 sm:-bottom-12",
+          ? "top-1/2 right-2 -translate-y-1/2"
+          : "bottom-2 left-1/2 -translate-x-1/2 rotate-90",
         className,
       )}
       disabled={!canScrollNext}

--- a/clipchronicle-landing/pages/index.tsx
+++ b/clipchronicle-landing/pages/index.tsx
@@ -1199,7 +1199,7 @@ export default function Home() {
           bg="bg-neutral-950"
           kicker="Use Cases"
         >
-          <div className="relative max-w-6xl mx-auto">
+          <div className="relative w-full">
             <Carousel opts={{ loop: true }}>
               <CarouselContent className="-ml-4">
                 {useCases.map((u) => (
@@ -1310,7 +1310,7 @@ export default function Home() {
           bg="bg-neutral-950"
           kicker="Testimonials"
         >
-          <div className="relative max-w-6xl mx-auto">
+          <div className="relative w-full">
             <Carousel opts={{ loop: true }}>
               <CarouselContent className="-ml-4">
                 {testimonials.map(([text, name]) => (


### PR DESCRIPTION
This pull request updates the positioning of the carousel navigation buttons in `carousel.tsx` to improve their responsiveness and layout on different screen sizes. The changes add more appropriate positioning for both horizontal and vertical orientations, especially on smaller screens.

**UI improvements for responsive carousel navigation:**

* Adjusted the `CarouselPrevious` button to use `left-2` and `top-2` for default positioning, with `sm:-left-12` and `sm:-top-12` for larger screens, improving its placement in both horizontal and vertical orientations (`clipchronicle-landing/components/ui/carousel.tsx`).
* Adjusted the `CarouselNext` button to use `right-2` and `bottom-2` for default positioning, with `sm:-right-12` and `sm:-bottom-12` for larger screens, improving its placement in both horizontal and vertical orientations (`clipchronicle-landing/components/ui/carousel.tsx`).